### PR TITLE
bypasses Linux-Gatsby issue by removing image

### DIFF
--- a/frontend/src/components/image.js
+++ b/frontend/src/components/image.js
@@ -1,32 +1,32 @@
-import React from "react"
-import { StaticQuery, graphql } from "gatsby"
-import Img from "gatsby-image"
+// import React from "react"
+// import { StaticQuery, graphql } from "gatsby"
+// import Img from "gatsby-image"
 
-/*
- * This component is built using `gatsby-image` to automatically serve optimized
- * images with lazy loading and reduced file sizes. The image is loaded using a
- * `StaticQuery`, which allows us to load the image from directly within this
- * component, rather than having to pass the image data down from pages.
- *
- * For more information, see the docs:
- * - `gatsby-image`: https://gatsby.dev/gatsby-image
- * - `StaticQuery`: https://gatsby.dev/staticquery
- */
+// /*
+//  * This component is built using `gatsby-image` to automatically serve optimized
+//  * images with lazy loading and reduced file sizes. The image is loaded using a
+//  * `StaticQuery`, which allows us to load the image from directly within this
+//  * component, rather than having to pass the image data down from pages.
+//  *
+//  * For more information, see the docs:
+//  * - `gatsby-image`: https://gatsby.dev/gatsby-image
+//  * - `StaticQuery`: https://gatsby.dev/staticquery
+//  */
 
-const Image = () => (
-  <StaticQuery
-    query={graphql`
-      query {
-        placeholderImage: file(relativePath: { eq: "gatsby-astronaut.png" }) {
-          childImageSharp {
-            fluid(maxWidth: 300) {
-              ...GatsbyImageSharpFluid
-            }
-          }
-        }
-      }
-    `}
-    render={data => <Img fluid={data.placeholderImage.childImageSharp.fluid} />}
-  />
-)
-export default Image
+// const Image = () => (
+//   <StaticQuery
+//     query={graphql`
+//       query {
+//         placeholderImage: file(relativePath: { eq: "gatsby-astronaut.png" }) {
+//           childImageSharp {
+//             fluid(maxWidth: 300) {
+//               ...GatsbyImageSharpFluid
+//             }
+//           }
+//         }
+//       }
+//     `}
+//     render={data => <Img fluid={data.placeholderImage.childImageSharp.fluid} />}
+//   />
+// )
+// export default Image

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "gatsby"
 
 import Layout from "../components/layout"
-import Image from "../components/image"
+// import Image from "../components/image"
 import SEO from "../components/seo"
 
 const IndexPage = () => (
@@ -18,7 +18,7 @@ const IndexPage = () => (
       <p>Children 3</p>
     </div>
     <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      <Image />
+      {/* <Image /> */}
     </div>
     <Link to="/page-2/">Go to page 2</Link>
   </Layout>


### PR DESCRIPTION
Was having trouble getting Gatsby local host to run. Known issue with Linux and Gatsby when loading large images.
https://github.com/gatsbyjs/gatsby/issues/13442
Just commented it out for now.